### PR TITLE
fix tooltips not working with shortcode

### DIFF
--- a/include/helpers/class.shortcode_common.php
+++ b/include/helpers/class.shortcode_common.php
@@ -1046,8 +1046,11 @@ if ( !class_exists( 'TagGroups_Shortcode_Common' ) ) {
             /**
              * Don't test for empty() because the user might need to display an empty title
              */
-            
-            if ( !is_null( $this->attributes->custom_title ) ) {
+            if (
+                ( property_exists( $this->attributes, 'custom_title' ) && ! is_null( $this->attributes->custom_title ) ) ||
+                ( property_exists( $this->attributes, 'custom_title_zero' ) && ! is_null( $this->attributes->custom_title_zero ) ) ||
+                ( property_exists( $this->attributes, 'custom_title_plural' ) && ! is_null( $this->attributes->custom_title_plural ) )
+            ) {
                 
                 if ( 0 == $post_count && property_exists( $this->attributes, 'custom_title_zero' ) && !is_null( $this->attributes->custom_title_zero ) ) {
                     $title = $this->attributes->custom_title_zero;
@@ -1066,6 +1069,7 @@ if ( !class_exists( 'TagGroups_Shortcode_Common' ) ) {
                  * 
                  * @return string
                  */
+                $title = (string) $title;
                 $title = apply_filters(
                     'tag_groups_custom_title',
                     $title,
@@ -1077,7 +1081,13 @@ if ( !class_exists( 'TagGroups_Shortcode_Common' ) ) {
                 $title = preg_replace( "/(\\{description\\})/", $description, $title );
                 $name = ( !empty($tag->name) ? esc_html( $tag->name ) : '' );
                 $title = preg_replace( "/(\\{name\\})/", $name, $title );
-                return preg_replace( "/(\\{count\\})/", $post_count, $title );
+                $title = preg_replace( "/(\\{count\\})/", $post_count, $title );
+                if ( trim($title) === '' ) {
+                    $tag_count_brackets = $this->attributes->show_tag_count ? '(' . $post_count . ')' : '';
+                    return $description . $tag_count_brackets;
+                  }
+          
+                  return $title;
             } else {
                 // use just description and number
                 $description = ( !empty($tag->description) ? esc_html( $tag->description ) . ' ' : '' );


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
fix tooltips not working with shortcode:
Resolved falling back to default when custom_title isn't set even though custom_title_zero and custom_title_plural is
Ensured there's a default when either or none is set
## Benefits
fix #102 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#102 
## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
