### PR TITLE
Build Gutenberg assets before packaging release zips

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "scripts": {
         "build": [
             "vendor/publishpress/dev-workspace/scripts/run.sh bash vendor/publishpress/dev-workspace/scripts/install-node-deps.sh /project wp-scripts webpack webpack-cli",
-            "@build:js",
+            "vendor/publishpress/dev-workspace/scripts/run.sh npm run build",
             "@pack:zip"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,13 @@
     "require-dev": {
         "publishpress/dev-workspace": "^1.3"
     },
+    "scripts": {
+        "build": [
+            "vendor/publishpress/dev-workspace/scripts/run.sh bash vendor/publishpress/dev-workspace/scripts/install-node-deps.sh /project wp-scripts webpack webpack-cli",
+            "@build:js",
+            "@pack:zip"
+        ]
+    },
     "extra": {
         "plugin-slug": "tag-groups",
         "plugin-name": "tag-groups",


### PR DESCRIPTION
## Description
`composer build` currently inherits the shared dev-workspace default, which only packages the repository tree into `dist/`. After `build/` was moved out of version control, that meant WordPress.org release zips could be published without the compiled Gutenberg bundle even though the source blocks still existed.

This change overrides the repo-level `build` script so the release path now:

1. installs the JS dependencies needed for the block build,
2. runs the Gutenberg webpack build, and
3. packages the plugin zip.

That keeps the compiled block assets present in WordPress.org releases instead of relying on a local prebuilt `build/` directory.

## Benefits
- WordPress.org release zips include `build/index.js`, `build/index.css`, and `build/index.asset.php`.
- Existing Tag Groups blocks stay registered in the block editor instead of showing as unsupported when the release zip is missing compiled assets.
- Local `composer build` now matches the requirements of the GitHub release deploy workflow.

## Possible drawbacks
- Release builds now spend extra time installing Node dependencies and compiling the Gutenberg assets.
- The first build on a clean environment will be slower because it has to hydrate the JS toolchain.

## Applicable issues
- WordPress.org support thread: https://wordpress.org/support/topic/gutenberg-is-gone/

## Checklist
- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch.
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [ ] I have mentioned the issue number in the pull request description text.
- [ ] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.

## Validation
- Ran the repo build path locally with `composer build`.
- Verified the produced package contains:
  - `tag-groups/build/index.asset.php`
  - `tag-groups/build/index.js`
  - `tag-groups/build/index.css`
  - `tag-groups/build/index-rtl.css`
- Verified the final artifact was created as `dist/tag-groups-2.2.1.zip`.
