### PR TITLE
fix(blocks): remove Gutenberg editor warning

### DIFF
--- a/src/guten-tag-accordion/block.js
+++ b/src/guten-tag-accordion/block.js
@@ -888,32 +888,6 @@ class tagGroupsAccordionCloudParameters extends Component {
               </div>
             )}
           </PanelBody>
-          <div className='chatty-mango-help-transform'>
-            <TagGroupsHelp
-              url={helpUrl}
-              product={this.helpProduct}
-              feature={this.helpFeature}
-              siteLang={siteLang}
-              topic='transform-your-block-for-more-options'
-            />
-            <div
-              className='dashicons-before dashicons-editor-code'
-              dangerouslySetInnerHTML={{
-                __html: __(
-                  'If you want to customize further options, you need to transform the block into a <b>shortcode block</b>.'
-                ),
-              }}
-            ></div>
-          </div>
-          <div
-            className='chatty-mango-inspector-help dashicons-before dashicons-admin-generic'
-            dangerouslySetInnerHTML={{
-              __html: __(
-                `The live preview of blocks can be turned on and off in the Tag Groups Settings under <a href="${gutenbergSettings}">Back End → Gutenberg</a>.`,
-                'tag-groups'
-              ),
-            }}
-          ></div>
         </div>
       </InspectorControls>,
       <div>

--- a/src/guten-tag-alphabet-index/block.js
+++ b/src/guten-tag-alphabet-index/block.js
@@ -737,32 +737,6 @@ class editFunction extends Component {
               </div>
             )}
           </PanelBody>
-          <div className='chatty-mango-help-transform'>
-            <TagGroupsHelp
-              url={helpUrl}
-              product={this.helpProduct}
-              feature={this.helpFeature}
-              siteLang={siteLang}
-              topic='transform-your-block-for-more-options'
-            />
-            <div
-              className='dashicons-before dashicons-editor-code'
-              dangerouslySetInnerHTML={{
-                __html: __(
-                  'If you want to customize further options, you need to transform the block into a <b>shortcode block</b>.'
-                ),
-              }}
-            ></div>
-          </div>
-          <div
-            className='chatty-mango-inspector-help dashicons-before dashicons-admin-generic'
-            dangerouslySetInnerHTML={{
-              __html: __(
-                `The live preview of blocks can be turned on and off in the Tag Groups Settings under <a href="${gutenbergSettings}">Back End → Gutenberg</a>.`,
-                'tag-groups'
-              ),
-            }}
-          ></div>
         </div>
       </InspectorControls>,
       <div>

--- a/src/guten-tag-alphabet/block.js
+++ b/src/guten-tag-alphabet/block.js
@@ -800,32 +800,6 @@ class tagGroupsAlphabeticalCloudParameters extends Component {
               </div>
             )}
           </PanelBody>
-          <div className='chatty-mango-help-transform'>
-            <TagGroupsHelp
-              url={helpUrl}
-              product={this.helpProduct}
-              feature={this.helpFeature}
-              siteLang={siteLang}
-              topic='transform-your-block-for-more-options'
-            />
-            <div
-              className='dashicons-before dashicons-editor-code'
-              dangerouslySetInnerHTML={{
-                __html: __(
-                  'If you want to customize further options, you need to transform the block into a <b>shortcode block</b>.'
-                ),
-              }}
-            ></div>
-          </div>
-          <div
-            className='chatty-mango-inspector-help dashicons-before dashicons-admin-generic'
-            dangerouslySetInnerHTML={{
-              __html: __(
-                `The live preview of blocks can be turned on and off in the Tag Groups Settings under <a href="${gutenbergSettings}">Back End → Gutenberg</a>.`,
-                'tag-groups'
-              ),
-            }}
-          ></div>
         </div>
       </InspectorControls>,
       <div>

--- a/src/guten-tag-list/block.js
+++ b/src/guten-tag-list/block.js
@@ -773,32 +773,6 @@ class editFunction extends Component {
               </div>
             )}
           </PanelBody>
-          <div className='chatty-mango-help-transform'>
-            <TagGroupsHelp
-              url={helpUrl}
-              product={this.helpProduct}
-              feature={this.helpFeature}
-              siteLang={siteLang}
-              topic='transform-your-block-for-more-options'
-            />
-            <div
-              className='dashicons-before dashicons-editor-code'
-              dangerouslySetInnerHTML={{
-                __html: __(
-                  'If you want to customize further options, you need to transform the block into a <b>shortcode block</b>.'
-                ),
-              }}
-            ></div>
-          </div>
-          <div
-            className='chatty-mango-inspector-help dashicons-before dashicons-admin-generic'
-            dangerouslySetInnerHTML={{
-              __html: __(
-                `The live preview of blocks can be turned on and off in the Tag Groups Settings under <a href="${gutenbergSettings}">Back End → Gutenberg</a>.`,
-                'tag-groups'
-              ),
-            }}
-          ></div>
         </div>
       </InspectorControls>,
       <div>

--- a/src/guten-tag-tabs/block.js
+++ b/src/guten-tag-tabs/block.js
@@ -846,32 +846,6 @@ class tagGroupsTabbedCloudParameters extends Component {
               </div>
             )}
           </PanelBody>
-          <div className='chatty-mango-help-transform'>
-            <TagGroupsHelp
-              url={helpUrl}
-              product={this.helpProduct}
-              feature={this.helpFeature}
-              siteLang={siteLang}
-              topic='transform-your-block-for-more-options'
-            />
-            <div
-              className='dashicons-before dashicons-editor-code'
-              dangerouslySetInnerHTML={{
-                __html: __(
-                  'If you want to customize further options, you need to transform the block into a <b>shortcode block</b>.'
-                ),
-              }}
-            ></div>
-          </div>
-          <div
-            className='chatty-mango-inspector-help dashicons-before dashicons-admin-generic'
-            dangerouslySetInnerHTML={{
-              __html: __(
-                `The live preview of blocks can be turned on and off in the Tag Groups Settings under <a href="${gutenbergSettings}">Back End → Gutenberg</a>.`,
-                'tag-groups'
-              ),
-            }}
-          ></div>
         </div>
       </InspectorControls>,
       <div>


### PR DESCRIPTION
## Summary

This removes the inspector warning shown inside the Tag Groups Gutenberg blocks.

## Root Cause

Each block editor variant rendered an inline warning telling users to transform the block into a shortcode block for more options, plus a second notice about live preview settings. That warning was hardcoded directly into each block edit component, so it always appeared in the Gutenberg sidebar.

## What Changed

- removed the warning footer from the tabbed cloud block
- removed the warning footer from the accordion block
- removed the warning footer from the alphabetical tabs block
- removed the warning footer from the alphabetical index block
- removed the warning footer from the tag list block

## Impact

Users no longer see that warning inside the Gutenberg editor when configuring Tag Groups blocks. Block behavior and server-side rendering remain unchanged.

## Validation

- reviewed the source diff to confirm only the warning UI was removed
- ran `npm ci`
- ran `npm run build`
- verified the warning strings no longer exist in either `src` or the compiled `build` output
