### PR TITLE
Add optional Groups feature toggle

### DIFF
--- a/include/admin/class.admin.php
+++ b/include/admin/class.admin.php
@@ -80,21 +80,23 @@ if (!class_exists('TagGroups_Admin')) {
                 $tag_group_role_edit_groups = TagGroups_Options::get_option('tag_group_role_edit_groups', 'edit_pages');
             }
 
-            $tag_group_post_types = TagGroups_Taxonomy::post_types_from_taxonomies($tag_group_taxonomies);
-            foreach ($tag_group_post_types as $post_type) {
-                if ('post' == $post_type) {
-                    $post_type_query = '';
-                } else {
-                    $post_type_query = '?post_type=' . $post_type;
-                }
+            if (TagGroups_Options::get_option('tag_group_enable_groups', 1)) {
+                $tag_group_post_types = TagGroups_Taxonomy::post_types_from_taxonomies($tag_group_taxonomies);
+                foreach ($tag_group_post_types as $post_type) {
+                    if ('post' == $post_type) {
+                        $post_type_query = '';
+                    } else {
+                        $post_type_query = '?post_type=' . $post_type;
+                    }
 
-                $submenu_page = add_submenu_page('edit.php' . $post_type_query, __('Tag Group Admin', 'tag-groups'), __('Tag Group Admin', 'tag-groups'), $tag_group_role_edit_groups, 'tag-groups_' . $post_type, array( 'TagGroups_Group_Admin', 'render_group_administration' ));
-                if (
-                    TagGroups_Utilities::is_premium_plan()
-                    && class_exists('TagGroups_Premium_Admin')
-                    && method_exists('TagGroups_Premium_Admin', 'add_screen_option')
-                ) {
-                    add_action("load-$submenu_page", array( 'TagGroups_Premium_Admin', 'add_screen_option' ));
+                    $submenu_page = add_submenu_page('edit.php' . $post_type_query, __('Tag Group Admin', 'tag-groups'), __('Tag Group Admin', 'tag-groups'), $tag_group_role_edit_groups, 'tag-groups_' . $post_type, array( 'TagGroups_Group_Admin', 'render_group_administration' ));
+                    if (
+                        TagGroups_Utilities::is_premium_plan()
+                        && class_exists('TagGroups_Premium_Admin')
+                        && method_exists('TagGroups_Premium_Admin', 'add_screen_option')
+                    ) {
+                        add_action("load-$submenu_page", array( 'TagGroups_Premium_Admin', 'add_screen_option' ));
+                    }
                 }
             }
         }

--- a/include/admin/class.group_admin.php
+++ b/include/admin/class.group_admin.php
@@ -21,6 +21,16 @@ if (!class_exists('TagGroups_Group_Admin')) {
         static function render_group_administration()
         {
             global  $tag_group_groups ;
+            if (!TagGroups_Options::get_option('tag_group_enable_groups', 1)) {
+                wp_die(
+                    esc_html__('The Groups feature is disabled.', 'tag-groups'),
+                    esc_html__('Tag Groups', 'tag-groups'),
+                    array(
+                        'response'  => 403,
+                        'back_link' => true,
+                    )
+                );
+            }
             $tag_group_show_filter_tags = TagGroups_Options::get_option('tag_group_show_filter_tags', 0);
             //tags
             $tag_group_show_filter = TagGroups_Options::get_option('tag_group_show_filter', 0);

--- a/include/admin/class.settings.php
+++ b/include/admin/class.settings.php
@@ -94,6 +94,7 @@ if (!class_exists('TagGroups_Settings')) {
             }
             $enabled_taxonomies = TagGroups_Taxonomy::get_enabled_taxonomies();
             $public_taxonomies = TagGroups_Taxonomy::get_public_taxonomies();
+            $tag_group_enable_groups = TagGroups_Options::get_option('tag_group_enable_groups', 1);
             self::add_header();
             $html = '';
             self::add_settings_help();
@@ -112,6 +113,7 @@ if (!class_exists('TagGroups_Settings')) {
                             $view->set(array(
                                 'public_taxonomies'  => $public_taxonomies,
                                 'enabled_taxonomies' => $enabled_taxonomies,
+                                'tag_group_enable_groups' => $tag_group_enable_groups,
                             ));
                             $view->render();
                             break;
@@ -673,6 +675,8 @@ if (!class_exists('TagGroups_Settings')) {
                         }
                     }
                     TagGroups_Taxonomy::update_enabled($taxonomies);
+                    $tag_group_enable_groups = ( isset($_POST['tag_group_enable_groups']) ? 1 : 0 );
+                    TagGroups_Options::update_option('tag_group_enable_groups', $tag_group_enable_groups);
                     TagGroups_Admin_Notice::add('success', __('Your settings have been saved.', 'tag-groups'));
                     break;
                 case 'backend':

--- a/include/helpers/class.options.php
+++ b/include/helpers/class.options.php
@@ -165,6 +165,11 @@ if (! class_exists('TagGroups_Options')) {
             'export' => true,
             'type'    => self::INTEGER
             );
+            $available_options['tag_group_enable_groups'] = array(
+            'origin' => self::TAG_GROUPS_PLUGIN,
+            'export' => true,
+            'type'    => self::INTEGER
+            );
             $available_options['tag_group_enable_group_public_api_access'] = array(
             'origin' => self::TAG_GROUPS_PLUGIN,
             'export' => true,

--- a/views/admin/settings_taxonomies.view.php
+++ b/views/admin/settings_taxonomies.view.php
@@ -10,6 +10,13 @@
   <div class="chatty-mango-settings-container">
     <form method="POST" action="<?php /* phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */ echo isset($_SERVER['REQUEST_URI']) ? esc_url(wp_unslash($_SERVER['REQUEST_URI'])) : ''; ?>">
       <?php echo wp_nonce_field('tag-groups-taxonomy', 'tag-groups-taxonomy-nonce', true, false); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+      <p>
+        <input id="tg_enable_groups" type="checkbox" name="tag_group_enable_groups" autocomplete="off" value="1" <?php if ($tag_group_enable_groups) :
+            ?> checked<?php 
+         endif; ?> />
+        <label for="tg_enable_groups"><?php _e('Enable Groups feature', 'tag-groups') ?></label>
+      </p>
+      <p><?php _e('Disable this option to hide the Tag Group Admin screens in the WordPress admin.', 'tag-groups') ?></p>
       <ul>
         <p><input id="tg_advanced_options_checkbox" type="checkbox" value=1 autocomplete="off" />
           <label for="tg_advanced_options_checkbox"><?php _e('Show hierarchical taxonomies. Not all Tag Groups features will work with these taxonomies.', 'tag-groups') ?></label></p>
@@ -30,7 +37,12 @@
                 ?> class="tg_advanced_options_items" style="display:none;" <?php 
              endif; ?>>
             <input type="checkbox" name="taxonomies[]" autocomplete="off" id="<?php echo esc_attr($taxonomy) ?>" value="<?php echo esc_attr($taxonomy) ?>" <?php if (in_array($taxonomy, $enabled_taxonomies)) :
-                ?> checked />&nbsp;<a href="<?php echo esc_url(TagGroups_Taxonomy::get_tag_group_admin_url($taxonomy)) ?>" title="<?php _e('go to tag group administration', 'tag-groups') ?>"><span class="dashicons dashicons-index-card tg_no_underline"></span></a>
+                ?> checked />
+              <?php if ($tag_group_enable_groups) : ?>
+                &nbsp;<a href="<?php echo esc_url(TagGroups_Taxonomy::get_tag_group_admin_url($taxonomy)) ?>" title="<?php _e('go to tag group administration', 'tag-groups') ?>"><span class="dashicons dashicons-index-card tg_no_underline"></span></a>
+              <?php else : ?>
+                &nbsp;<span class="dashicons dashicons-index-card tg_no_underline tg_faded"></span>
+              <?php endif; ?>
                                                                               <?php else : ?>
             />&nbsp;<span class="dashicons dashicons-index-card tg_no_underline tg_faded"></span>
                                                                               <?php endif; ?>

--- a/views/admin/settings_taxonomies.view.php
+++ b/views/admin/settings_taxonomies.view.php
@@ -11,9 +11,7 @@
     <form method="POST" action="<?php /* phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */ echo isset($_SERVER['REQUEST_URI']) ? esc_url(wp_unslash($_SERVER['REQUEST_URI'])) : ''; ?>">
       <?php echo wp_nonce_field('tag-groups-taxonomy', 'tag-groups-taxonomy-nonce', true, false); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
       <p>
-        <input id="tg_enable_groups" type="checkbox" name="tag_group_enable_groups" autocomplete="off" value="1" <?php if ($tag_group_enable_groups) :
-            ?> checked<?php 
-         endif; ?> />
+        <input id="tg_enable_groups" type="checkbox" name="tag_group_enable_groups" autocomplete="off" value="1" <?php checked($tag_group_enable_groups); ?> />
         <label for="tg_enable_groups"><?php _e('Enable Groups feature', 'tag-groups') ?></label>
       </p>
       <p><?php _e('Disable this option to hide the Tag Group Admin screens in the WordPress admin.', 'tag-groups') ?></p>
@@ -40,8 +38,6 @@
                 ?> checked />
               <?php if ($tag_group_enable_groups) : ?>
                 &nbsp;<a href="<?php echo esc_url(TagGroups_Taxonomy::get_tag_group_admin_url($taxonomy)) ?>" title="<?php _e('go to tag group administration', 'tag-groups') ?>"><span class="dashicons dashicons-index-card tg_no_underline"></span></a>
-              <?php else : ?>
-                &nbsp;<span class="dashicons dashicons-index-card tg_no_underline tg_faded"></span>
               <?php endif; ?>
                                                                               <?php else : ?>
             />&nbsp;<span class="dashicons dashicons-index-card tg_no_underline tg_faded"></span>


### PR DESCRIPTION
## Summary
- add a persisted toggle on the Tag Groups settings taxonomy screen to enable or disable the Groups feature
- hide `edit.php?page=tag-groups_{post_type}` submenu pages when the feature is disabled
- suppress the settings-screen admin links to Tag Group Admin and block direct access to the hidden page

## Testing
- php -l include/helpers/class.options.php
- php -l include/admin/class.settings.php
- php -l include/admin/class.admin.php
- php -l include/admin/class.group_admin.php
- php -l views/admin/settings_taxonomies.view.php
